### PR TITLE
Version 1.5.0

### DIFF
--- a/Build/.nuke/build.schema.json
+++ b/Build/.nuke/build.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Build Schema",
   "$ref": "#/definitions/build",
+  "title": "Build Schema",
   "definitions": {
     "build": {
       "type": "object",

--- a/Build/.nuke/build.schema.json
+++ b/Build/.nuke/build.schema.json
@@ -42,9 +42,6 @@
             "VSCode"
           ]
         },
-        "InstallationFiles": {
-          "type": "string"
-        },
         "IssConfiguration": {
           "type": "string"
         },

--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -6,6 +6,7 @@ using ricaun.Nuke.Components;
 #if !PUBLISH_ONLY_REVIT
 class Build : NukeBuild, IPublishPack, IRevitPackageBuilder
 {
+    string IHazInstallationFiles.InstallationFiles => "InstallationFiles";
     string IHazPackageBuilderProject.Name => "Example";
     string IHazRevitPackageBuilder.Application => "Revit.App";
     string IHazRevitPackageBuilder.ApplicationType => "Application";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.5.0] / 2023-05-31
 ### Updated
 - Update `ricaun.Nuke` to `1.5.0`
+### Fixed
+- Fix `PathConstruction` to `Globbing`
+- Fix `FileSystemTasks` to `AbsolutePathExtensions`
+- Fix `ToolPathResolver` to `NuGetToolPathResolver`
 
 ## [1.4.3] / 2023-05-06
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix `PathConstruction` to `Globbing`
 - Fix `FileSystemTasks` to `AbsolutePathExtensions`
 - Fix `ToolPathResolver` to `NuGetToolPathResolver`
+- Fix `InstallationFiles` when folder.
 
 ## [1.4.3] / 2023-05-06
 ### Updated

--- a/ricaun.Nuke.PackageBuilder/Components/IHazInstallationFiles.cs
+++ b/ricaun.Nuke.PackageBuilder/Components/IHazInstallationFiles.cs
@@ -6,6 +6,7 @@ using ricaun.Nuke.Extensions;
 using System;
 using System.IO;
 using System.IO.Compression;
+using System.Security.Policy;
 
 namespace ricaun.Nuke.Components
 {
@@ -15,7 +16,7 @@ namespace ricaun.Nuke.Components
     public interface IHazInstallationFiles : IHazPackageBuilderProject, IHazSolution, INukeBuild
     {
         /// <summary>
-        /// Folder InstallationFiles 
+        /// Folder/Url (default: InstallationFiles)
         /// </summary>
         [Parameter]
         string InstallationFiles => TryGetValue(() => InstallationFiles) ?? "InstallationFiles";
@@ -61,6 +62,7 @@ namespace ricaun.Nuke.Components
         {
             try
             {
+                new Uri(url);
                 var fileName = Path.GetFileName(url);
                 var file = Path.Combine(downloadFolder, fileName);
 

--- a/ricaun.Nuke.PackageBuilder/Components/IHazInstallationFiles.cs
+++ b/ricaun.Nuke.PackageBuilder/Components/IHazInstallationFiles.cs
@@ -47,7 +47,7 @@ namespace ricaun.Nuke.Components
             Serilog.Log.Information($"InstallationFiles: {InstallationFiles}");
             DownloadFilesAndUnzip(InstallationFiles, packageBuilderDirectory);
 
-            PathConstruction.GlobFiles(InstallationFilesDirectory, "*")
+            Globbing.GlobFiles(InstallationFilesDirectory, "*")
                 .ForEach(file => FileSystemTasks.CopyFileToDirectory(file, packageBuilderDirectory));
         }
 

--- a/ricaun.Nuke.PackageBuilder/Components/Revit/IRevitPackageBuilder.cs
+++ b/ricaun.Nuke.PackageBuilder/Components/Revit/IRevitPackageBuilder.cs
@@ -75,11 +75,11 @@ namespace ricaun.Nuke.Components
             // Deploy File
             var outputInno = OutputDirectory;
             var packageBuilderDirectory = GetMaxPathFolderOrTempFolder(PackageBuilderDirectory);
-            var issFiles = PathConstruction.GlobFiles(packageBuilderDirectory, $"*{projectName}.iss");
+            var issFiles = Globbing.GlobFiles(packageBuilderDirectory, $"*{projectName}.iss");
             issFiles.ForEach(file =>
             {
                 InnoSetupTasks.InnoSetup(config => config
-                    .SetProcessToolPath(ToolPathResolver.GetPackageExecutable("Tools.InnoSetup", "ISCC.exe"))
+                    .SetProcessToolPath(NuGetToolPathResolver.GetPackageExecutable("Tools.InnoSetup", "ISCC.exe"))
                     .SetScriptFile(file)
                     .SetOutputDir(outputInno));
             });
@@ -88,12 +88,12 @@ namespace ricaun.Nuke.Components
             SignFolder(outputInno);
 
             // Zip exe Files
-            var exeFiles = PathConstruction.GlobFiles(outputInno, "**/*.exe");
+            var exeFiles = Globbing.GlobFiles(outputInno, "**/*.exe");
             exeFiles.ForEach(file => ZipExtension.ZipFileCompact(file, projectNameVersion));
 
             if (outputInno != ReleaseDirectory)
             {
-                PathConstruction.GlobFiles(outputInno, "**/*.zip")
+                Globbing.GlobFiles(outputInno, "**/*.zip")
                     .ForEach(file => FileSystemTasks.CopyFileToDirectory(file, ReleaseDirectory));
             }
 
@@ -118,7 +118,7 @@ namespace ricaun.Nuke.Components
         /// <param name="directory"></param>
         private void CreateRevitAddinOnProjectFiles(Project project, AbsolutePath directory)
         {
-            var addInFiles = PathConstruction.GlobFiles(directory, $"**/*{project.Name}*.dll")
+            var addInFiles = Globbing.GlobFiles(directory, $"**/*{project.Name}*.dll")
                             .Where(e => RevitExtension.HasRevitVersion(e));
 
             addInFiles.ForEach(file =>
@@ -145,18 +145,18 @@ namespace ricaun.Nuke.Components
             var file = packageBuilderDirectory;
             Serilog.Log.Information($"Path Max: {file.ToString().Length} - {Path.GetFileName(file)}");
 
-            PathConstruction.GlobFiles(packageBuilderDirectory, "**/*")
+            Globbing.GlobFiles(packageBuilderDirectory, "**/*")
                 .ForEach(file =>
                 {
                     Serilog.Log.Information($"Path Max: {file.ToString().Length} - {Path.GetFileName(file)}");
                 });
 
-            var max = PathConstruction.GlobFiles(packageBuilderDirectory, "**/*").Max(file => file.ToString().Length);
+            var max = Globbing.GlobFiles(packageBuilderDirectory, "**/*").Max(file => file.ToString().Length);
 
             Serilog.Log.Information($"Path Max: {max}");
             if (max >= MAX_PATH)
             {
-                if (FileSystemTasks.DirectoryExists(temp)) FileSystemTasks.DeleteDirectory(temp);
+                if (temp.DirectoryExists()) temp.DeleteDirectory();
                 FileSystemTasks.CopyDirectoryRecursively(packageBuilderDirectory, temp);
                 var limit = max - file.ToString().Length + temp.ToString().Length;
                 Serilog.Log.Information($"Path Max: {limit} - {temp}");

--- a/ricaun.Nuke.PackageBuilder/PackageBuilder/Revit/IssRevitBuilder.cs
+++ b/ricaun.Nuke.PackageBuilder/PackageBuilder/Revit/IssRevitBuilder.cs
@@ -53,16 +53,16 @@ namespace ricaun.Nuke.Components
                     .DisableDirPage(YesNo.Yes)
                     .ShowLanguageDialog(YesNo.No);
 
-            if (FileSystemTasks.FileExists(packageBuilderDirectory / issConfiguration.Icon))
+            if ((packageBuilderDirectory / issConfiguration.Icon).FileExists())
                 setup.SetupIconFile(issConfiguration.Icon);
 
-            if (FileSystemTasks.FileExists(packageBuilderDirectory / issConfiguration.Image))
+            if ((packageBuilderDirectory / issConfiguration.Image).FileExists())
                 setup.WizardImageFile(issConfiguration.Image);
 
-            if (FileSystemTasks.FileExists(packageBuilderDirectory / issConfiguration.ImageSmall))
+            if ((packageBuilderDirectory / issConfiguration.ImageSmall).FileExists())
                 setup.WizardSmallImageFile(issConfiguration.ImageSmall);
 
-            if (FileSystemTasks.FileExists(packageBuilderDirectory / issConfiguration.Licence))
+            if ((packageBuilderDirectory / issConfiguration.Licence).FileExists())
                 setup.LicenseFile(issConfiguration.Licence);
 
             Files.CreateEntry(source: sourceFiles, destDir: $@"\\?\{InnoConstants.Directories.App}")
@@ -78,7 +78,7 @@ namespace ricaun.Nuke.Components
                     var language = Languages.CreateEntry(name: IssLanguageLicence.Name,
                         messagesFile: IssLanguageLicence.MessagesFile);
 
-                    if (FileSystemTasks.FileExists(packageBuilderDirectory / IssLanguageLicence.Licence))
+                    if ((packageBuilderDirectory / IssLanguageLicence.Licence).FileExists())
                         language.LicenseFile(IssLanguageLicence.Licence);
                 }
             }

--- a/ricaun.Nuke.PackageBuilder/PackageBuilder/Revit/RevitContentsBuilder.cs
+++ b/ricaun.Nuke.PackageBuilder/PackageBuilder/Revit/RevitContentsBuilder.cs
@@ -42,7 +42,7 @@ namespace ricaun.Nuke.Components
             CompanyDetails
                 .Create(project.GetCompany());
 
-            var addinFiles = PathConstruction.GlobFiles(bundleDirectory, $"**/*{project.Name}*.addin");
+            var addinFiles = Globbing.GlobFiles(bundleDirectory, $"**/*{project.Name}*.addin");
 
             //var lastVersion = 0;
             //foreach (var addinFile in addinFiles)
@@ -97,7 +97,7 @@ namespace ricaun.Nuke.Components
             var moduleName = ((string)addinFile).Replace(bundleDirectory, ".");
 
             var folder = Path.GetDirectoryName(addinFile);
-            var dll = PathConstruction.GlobFiles(folder, $"*{project.Name}*.dll")
+            var dll = Globbing.GlobFiles(folder, $"*{project.Name}*.dll")
                 .Where(e => RevitExtension.HasRevitVersion(e))
                 .FirstOrDefault();
 


### PR DESCRIPTION
### Updated
- Update `ricaun.Nuke` to `1.5.0`
### Fixed
- Fix `PathConstruction` to `Globbing`
- Fix `FileSystemTasks` to `AbsolutePathExtensions`
- Fix `ToolPathResolver` to `NuGetToolPathResolver`
- Fix `InstallationFiles` when folder.