### PR TITLE
Version 1.6.3

### DIFF
--- a/Build/.nuke/build.schema.json
+++ b/Build/.nuke/build.schema.json
@@ -90,6 +90,9 @@
         "ProjectNameFolder": {
           "type": "boolean"
         },
+        "ProjectRemoveAppendTargetFrameworkFolder": {
+          "type": "boolean"
+        },
         "ProjectVersionFolder": {
           "type": "boolean"
         },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.6.3] / 2023-12-06
+### Features
+- Add `ProjectRemoveTargetFrameworkFolder` to remove `net` folder in `PackageBuilder`.
+- Update `ReleasePackageBuilder` to not create the Inno installation when false.
+### Updated
+- Update `Autodesk.PackageBuilder` to `1.0.6`
+### Example
+- Update `AppendTargetFrameworkToOutputPath` to `true`.
+
 ## [1.6.2] / 2023-11-19
 ### Updated
 - Update `ricaun.Nuke` to `1.7.2`
@@ -264,6 +273,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - First Release
 
 [vNext]: ../../compare/1.0.0...HEAD
+[1.6.3]: ../../compare/1.6.2...1.6.3
 [1.6.2]: ../../compare/1.6.1...1.6.2
 [1.6.1]: ../../compare/1.6.0...1.6.1
 [1.6.0]: ../../compare/1.5.1...1.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update `ReleasePackageBuilder` to not create the Inno installation when false.
 ### Updated
 - Update `Autodesk.PackageBuilder` to `1.0.6`
+- Update `ricaun.Nuke` to `1.7.3`
 ### Example
 - Update `AppendTargetFrameworkToOutputPath` to `true`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.6.3] / 2023-12-06
+## [1.6.3] / 2023-12-06 - 2023-12-22
 ### Features
 - Add `ProjectRemoveTargetFrameworkFolder` to remove `net` folder in `PackageBuilder`.
 - Update `ReleasePackageBuilder` to not create the Inno installation when false.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>1.6.3-beta</Version>
+		<Version>1.6.3</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>1.6.2</Version>
+		<Version>1.6.3</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>1.6.3</Version>
+		<Version>1.6.3-alpha</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>1.6.3-alpha</Version>
+		<Version>1.6.3-beta</Version>
 	</PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ bool IHazPackageBuilderProject.ReleasePackageBuilder => true;
 bool IHazPackageBuilderProject.ReleaseBundle => true;
 bool IHazPackageBuilderProject.ProjectNameFolder => true;
 bool IHazPackageBuilderProject.ProjectVersionFolder => true;
+bool IHazPackageBuilderProject.ProjectRemoveTargetFrameworkFolder => true;
 ```
 
 ### IHazRevitPackageBuilder

--- a/RevitAddin.PackageBuilder.Example/Revit/App.cs
+++ b/RevitAddin.PackageBuilder.Example/Revit/App.cs
@@ -12,7 +12,8 @@ namespace RevitAddin.PackageBuilder.Example.Revit
         public Result OnStartup(UIControlledApplication application)
         {
             ribbonPanel = application.CreatePanel(GetRevitVersion());
-            ribbonPanel.CreatePushButton<Commands.Command>(Properties.Resource.Text);
+            ribbonPanel.CreatePushButton<Commands.Command>(Properties.Resource.Text)
+                .SetLargeImage("/UIFrameworkRes;component/ribbon/images/revit.ico");
             return Result.Succeeded;
         }
 

--- a/RevitAddin.PackageBuilder.Example/RevitAddin.PackageBuilder.Example.csproj
+++ b/RevitAddin.PackageBuilder.Example/RevitAddin.PackageBuilder.Example.csproj
@@ -6,7 +6,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <UseWPF>true</UseWPF>
     <LangVersion>Latest</LangVersion>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <Configurations>Debug 2019;2019;Debug 2020;2020;Debug 2021;2021;Debug 2022;2022;2023;2017</Configurations>
   </PropertyGroup>

--- a/ricaun.Nuke.PackageBuilder/Components/IHazPackageBuilderProject.cs
+++ b/ricaun.Nuke.PackageBuilder/Components/IHazPackageBuilderProject.cs
@@ -43,6 +43,12 @@ namespace ricaun.Nuke.Components
         bool ProjectVersionFolder => TryGetValue<bool?>(() => ProjectVersionFolder) ?? true;
 
         /// <summary>
+        /// Add ProjectRemoveTargetFrameworkFolder on the Contents (default: true)
+        /// </summary>
+        [Parameter]
+        bool ProjectRemoveTargetFrameworkFolder => TryGetValue<bool?>(() => ProjectRemoveTargetFrameworkFolder) ?? true;
+
+        /// <summary>
         /// GetPackageBuilderProject by the Name
         /// </summary>
         /// <returns></returns>

--- a/ricaun.Nuke.PackageBuilder/Extensions/AppendTargetFrameworkExtension.cs
+++ b/ricaun.Nuke.PackageBuilder/Extensions/AppendTargetFrameworkExtension.cs
@@ -24,7 +24,7 @@ namespace ricaun.Nuke.Extensions
                         if (targetFrameworkDirectory.Parent.ContainsFile("*") == false)
                         {
                             Serilog.Log.Information($"CopyDirectoryRecursively: {directoryName} to {targetFrameworkDirectory.Parent.Name}");
-                            Serilog.Log.Warning($"RemoveTargetFrameworkDirectory: {directoryName} move to {targetFrameworkDirectory.Parent.Name}");
+                            Serilog.Log.Information($"RemoveTargetFrameworkDirectory: {directoryName} move to {targetFrameworkDirectory.Parent.Name}");
                             FileSystemTasks.CopyDirectoryRecursively(targetFrameworkDirectory, targetFrameworkDirectory.Parent, DirectoryExistsPolicy.Merge);
                             targetFrameworkDirectory.DeleteDirectory();
                         }

--- a/ricaun.Nuke.PackageBuilder/Extensions/AppendTargetFrameworkExtension.cs
+++ b/ricaun.Nuke.PackageBuilder/Extensions/AppendTargetFrameworkExtension.cs
@@ -1,0 +1,35 @@
+﻿using Nuke.Common.IO;
+using Nuke.Common.Utilities.Collections;
+
+namespace ricaun.Nuke.Extensions
+{
+    /// <summary>
+    /// AppendTargetFrameworkExtension
+    /// </summary>
+    public static class AppendTargetFrameworkExtension
+    {
+        /// <summary>
+        /// RemoveAppendTargetFrameworkDirectory
+        /// </summary>
+        /// <param name="contentsDirectory"></param>
+        public static void RemoveAppendTargetFrameworkDirectory(AbsolutePath contentsDirectory)
+        {
+            Globbing.GlobDirectories(contentsDirectory, "**/net*")
+                .ForEach(targetFrameworkDirectory =>
+                {
+                    var directoryName = targetFrameworkDirectory.Name;
+                    Serilog.Log.Information($"RemoveAppendTargetFrameworkDirectory: {directoryName} - {targetFrameworkDirectory}");
+                    if (targetFrameworkDirectory.Exists())
+                    {
+                        if (targetFrameworkDirectory.Parent.ContainsFile("*") == false)
+                        {
+                            Serilog.Log.Information($"CopyDirectoryRecursively: {directoryName} to {targetFrameworkDirectory.Parent.Name}");
+                            Serilog.Log.Warning($"RemoveTargetFrameworkDirectory: {directoryName} move to {targetFrameworkDirectory.Parent.Name}");
+                            FileSystemTasks.CopyDirectoryRecursively(targetFrameworkDirectory, targetFrameworkDirectory.Parent, DirectoryExistsPolicy.Merge);
+                            targetFrameworkDirectory.DeleteDirectory();
+                        }
+                    }
+                });
+        }
+    }
+}


### PR DESCRIPTION
### Features
- Add `ProjectRemoveTargetFrameworkFolder` to remove `net` folder in `PackageBuilder`.
- Update `ReleasePackageBuilder` to not create the Inno installation when false.
### Updated
- Update `Autodesk.PackageBuilder` to `1.0.6`
- Update `ricaun.Nuke` to `1.7.3`
### Example
- Update `AppendTargetFrameworkToOutputPath` to `true`.