### PR TITLE
Version 1.11.3

### DIFF
--- a/Build/.nuke/build.schema.json
+++ b/Build/.nuke/build.schema.json
@@ -162,6 +162,13 @@
         "ReleasePackageBuilder": {
           "type": "boolean"
         },
+        "RevitContext": {
+          "type": "boolean"
+        },
+        "RevitContextVersion": {
+          "type": "integer",
+          "format": "int32"
+        },
         "SignFile": {
           "type": "string",
           "default": "Secrets must be entered via 'nuke :secrets [profile]'"

--- a/Build/.nuke/build.schema.json
+++ b/Build/.nuke/build.schema.json
@@ -162,7 +162,7 @@
         "ReleasePackageBuilder": {
           "type": "boolean"
         },
-        "RevitContext": {
+        "RevitContextIsolation": {
           "type": "boolean"
         },
         "RevitContextVersion": {

--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -16,6 +16,7 @@ class Build : NukeBuild, IPublishPack, IRevitPackageBuilder, ITest, IPrePack
     string IHazPackageBuilderProject.Name => "Example";
     string IHazRevitPackageBuilder.Application => "Revit.App";
     string IHazRevitPackageBuilder.ApplicationType => "Application";
+    //bool IHazRevitPackageBuilder.RevitContextIsolation => true;
     string IHazRevitPackageBuilder.RevitContextName => "MyContextName";
     public static int Main() => Execute<Build>(x => x.From<IPublishPack>().Build);
 

--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -16,6 +16,7 @@ class Build : NukeBuild, IPublishPack, IRevitPackageBuilder, ITest, IPrePack
     string IHazPackageBuilderProject.Name => "Example";
     string IHazRevitPackageBuilder.Application => "Revit.App";
     string IHazRevitPackageBuilder.ApplicationType => "Application";
+    string IHazRevitPackageBuilder.RevitContextName => "MyContextName";
     public static int Main() => Execute<Build>(x => x.From<IPublishPack>().Build);
 
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.11.3] / 2026-04-08
+### Features
+- Support `IHazRevitPackageBuilder.RevitContext` to enable `UseRevitContext` in the addin build.
+### Updated
+- Add `IHazRevitPackageBuilder.RevitContext` to enable `ManifestSettings.UseRevitContext` in the addin build.
+- Add `IHazRevitPackageBuilder.RevitContextName` to set the `ManifestSettings.ContextName` in the addin build.
+- Add `IHazRevitPackageBuilder.RevitContextVersion` to set the lowest version that support the `ManifestSettings` in the addin build.
+
 ## [1.11.2] / 2026-03-22 - 2026-03-30
 ### Features
 - Update `ricaun.Nuke` to `1.11.2` to support `.sln` and/or `.slnx` in the `Solution` in `net10.0`
@@ -390,6 +398,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - First Release
 
 [vNext]: ../../compare/1.0.0...HEAD
+[1.11.3]: ../../compare/1.11.2...1.11.3
 [1.11.2]: ../../compare/1.11.1...1.11.2
 [1.11.1]: ../../compare/1.11.0...1.11.1
 [1.11.0]: ../../compare/1.10.0...1.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.11.3] / 2026-04-08
 ### Features
-- Support `IHazRevitPackageBuilder.RevitContext` to enable `UseRevitContext` in the addin build.
+- Support `RevitContextIsolation` to enable `UseRevitContext` in the addin build.
 ### Updated
-- Add `IHazRevitPackageBuilder.RevitContext` to enable `ManifestSettings.UseRevitContext` in the addin build.
+- Add `IHazRevitPackageBuilder.RevitContextIsolation` to enable `ManifestSettings.UseRevitContext` to `false` in the addin build.
 - Add `IHazRevitPackageBuilder.RevitContextName` to set the `ManifestSettings.ContextName` in the addin build.
 - Add `IHazRevitPackageBuilder.RevitContextVersion` to set the lowest version that support the `ManifestSettings` in the addin build.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `IHazRevitPackageBuilder.RevitContextIsolation` to enable `ManifestSettings.UseRevitContext` to `false` in the addin build.
 - Add `IHazRevitPackageBuilder.RevitContextName` to set the `ManifestSettings.ContextName` in the addin build.
 - Add `IHazRevitPackageBuilder.RevitContextVersion` to set the lowest version that support the `ManifestSettings` in the addin build.
+- Add `RevitProjectAddInsBuilderExtension` to enable `AddInContextIsolation`.
 
 ## [1.11.2] / 2026-03-22 - 2026-03-30
 ### Features

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.11.3-alpha</Version>
+    <Version>1.11.3-beta</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.11.2</Version>
+    <Version>1.11.3-alpha</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.11.3-rc</Version>
+    <Version>1.11.3</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.11.3-beta</Version>
+    <Version>1.11.3-rc</Version>
   </PropertyGroup>
 </Project>

--- a/RevitAddin.PackageBuilder.Example/Revit/App.cs
+++ b/RevitAddin.PackageBuilder.Example/Revit/App.cs
@@ -14,7 +14,8 @@ namespace RevitAddin.PackageBuilder.Example.Revit
             ribbonPanel = application.CreatePanel(GetRevitVersion());
             ribbonPanel.CreatePushButton<Commands.Command>(Properties.Resource.Text)
                 .SetLargeImage("/UIFrameworkRes;component/ribbon/images/revit.ico")
-                .SetLongDescription(ContextUtils.GetName());
+                .SetLongDescription($"{ContextUtils.GetName()}\n{ContextUtils.GetNumber()}");
+
             return Result.Succeeded;
         }
 

--- a/RevitAddin.PackageBuilder.Example/Revit/App.cs
+++ b/RevitAddin.PackageBuilder.Example/Revit/App.cs
@@ -13,7 +13,8 @@ namespace RevitAddin.PackageBuilder.Example.Revit
         {
             ribbonPanel = application.CreatePanel(GetRevitVersion());
             ribbonPanel.CreatePushButton<Commands.Command>(Properties.Resource.Text)
-                .SetLargeImage("/UIFrameworkRes;component/ribbon/images/revit.ico");
+                .SetLargeImage("/UIFrameworkRes;component/ribbon/images/revit.ico")
+                .SetLongDescription(ContextUtils.GetName());
             return Result.Succeeded;
         }
 
@@ -25,7 +26,7 @@ namespace RevitAddin.PackageBuilder.Example.Revit
 
         public static string GetRevitVersion()
         {
-#if Revit2017 
+#if Revit2017
             return "2017";
 #elif Revit2018
             return "2018";
@@ -39,6 +40,14 @@ namespace RevitAddin.PackageBuilder.Example.Revit
             return "2022";
 #elif Revit2023
             return "2023";
+#elif Revit2024
+            return "2024";
+#elif Revit2025
+            return "2025";
+#elif Revit2026
+            return "2026";
+#elif Revit2027
+            return "2027";
 #else
             return "Undefined";
 #endif

--- a/RevitAddin.PackageBuilder.Example/Revit/ContextUtils.cs
+++ b/RevitAddin.PackageBuilder.Example/Revit/ContextUtils.cs
@@ -11,5 +11,16 @@ namespace RevitAddin.PackageBuilder.Example.Revit
             return "Default";
 #endif
         }
+
+        public static string GetNumber()
+        {
+#if NET
+            var context = System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(typeof(ContextUtils).Assembly);
+            var split = context.ToString().Split('#');
+            return split[split.Length - 1];
+#else
+            return "0";
+#endif
+        }
     }
 }

--- a/RevitAddin.PackageBuilder.Example/Revit/ContextUtils.cs
+++ b/RevitAddin.PackageBuilder.Example/Revit/ContextUtils.cs
@@ -1,0 +1,15 @@
+namespace RevitAddin.PackageBuilder.Example.Revit
+{
+    public static class ContextUtils
+    {
+        public static string GetName()
+        {
+#if NET
+            var context = System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(typeof(ContextUtils).Assembly);
+            return context.Name;
+#else
+            return "Default";
+#endif
+        }
+    }
+}

--- a/RevitAddin.PackageBuilder.Example/RevitAddin.PackageBuilder.Example.csproj
+++ b/RevitAddin.PackageBuilder.Example/RevitAddin.PackageBuilder.Example.csproj
@@ -8,7 +8,7 @@
     <LangVersion>Latest</LangVersion>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
-    <Configurations>Debug 2019;2019;Debug 2020;2020;Debug 2021;2021;Debug 2022;2022;2023;2017;2025</Configurations>
+    <Configurations>Debug 2019;2019;Debug 2020;2020;Debug 2021;2021;Debug 2022;2022;2023;2017;2025;2027</Configurations>
   </PropertyGroup>
 
   <!-- RevitVersion -->
@@ -71,6 +71,12 @@
       <PropertyGroup>
         <RevitVersion>2026</RevitVersion>
         <TargetFramework>net8.0-windows</TargetFramework>
+      </PropertyGroup>
+    </When>
+    <When Condition="$(Configuration.Contains('2027'))">
+      <PropertyGroup>
+        <RevitVersion>2027</RevitVersion>
+        <TargetFramework>net10.0-windows</TargetFramework>
       </PropertyGroup>
     </When>
     <Otherwise>
@@ -150,7 +156,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Revit_All_Main_Versions_API_x64" Version="$(RevitVersion).*" IncludeAssets="build; compile" PrivateAssets="All" />
+    <PackageReference Include="Revit_All_Main_Versions_API_x64" Version="$(RevitVersion).*-*" IncludeAssets="build; compile" PrivateAssets="All" />
     <PackageReference Include="ricaun.Revit.UI" Version="*" />
   </ItemGroup>
 

--- a/ricaun.Nuke.PackageBuilder.slnx
+++ b/ricaun.Nuke.PackageBuilder.slnx
@@ -7,6 +7,7 @@
     <BuildType Name="2022" />
     <BuildType Name="2023" />
     <BuildType Name="2025" />
+    <BuildType Name="2027" />
     <BuildType Name="Debug" />
     <BuildType Name="Release" />
   </Configurations>
@@ -23,6 +24,7 @@
     <BuildType Solution="2022|*" Project="Release" />
     <BuildType Solution="2023|*" Project="Release" />
     <BuildType Solution="2025|*" Project="Debug" />
+    <BuildType Solution="2027|*" Project="Debug" />
     <Build Project="false" />
   </Project>
   <Project Path="RevitAddin.PackageBuilder.Example/RevitAddin.PackageBuilder.Example.csproj">
@@ -38,6 +40,7 @@
     <BuildType Solution="2022|*" Project="Debug" />
     <BuildType Solution="2023|*" Project="Debug" />
     <BuildType Solution="2025|*" Project="Release" />
+    <BuildType Solution="2027|*" Project="Release" />
   </Project>
   <Project Path="ricaun.Nuke.PackageBuilder/ricaun.Nuke.PackageBuilder.csproj">
     <BuildType Solution="2017|*" Project="Release" />
@@ -47,6 +50,7 @@
     <BuildType Solution="2022|*" Project="Release" />
     <BuildType Solution="2023|*" Project="Release" />
     <BuildType Solution="2025|*" Project="Debug" />
+    <BuildType Solution="2027|*" Project="Debug" />
     <Build Solution="2017|*" Project="false" />
     <Build Solution="2019|*" Project="false" />
     <Build Solution="2020|*" Project="false" />
@@ -54,5 +58,6 @@
     <Build Solution="2022|*" Project="false" />
     <Build Solution="2023|*" Project="false" />
     <Build Solution="2025|*" Project="false" />
+    <Build Solution="2027|*" Project="false" />
   </Project>
 </Solution>

--- a/ricaun.Nuke.PackageBuilder/Components/Revit/IHazRevitPackageBuilder.cs
+++ b/ricaun.Nuke.PackageBuilder/Components/Revit/IHazRevitPackageBuilder.cs
@@ -52,5 +52,23 @@ namespace ricaun.Nuke.Components
         /// </summary>
         [Parameter]
         string VendorDescription => TryGetValue(() => VendorDescription) ?? VendorId;
+
+        /// <summary>
+        /// RevitContext (Support in Revit 2027+)
+        /// </summary>
+        [Parameter]
+        bool RevitContext => TryGetValue<bool?>(() => RevitContext) ?? false;
+
+        /// <summary>
+        /// RevitContextName (Support in Revit 2027+)
+        /// </summary>
+        [Parameter]
+        string RevitContextName => TryGetValue(() => RevitContextName) ?? null;
+
+        /// <summary>
+        /// RevitContextVersion (Default 2027) (Lowest version to add `ManifestSettings.UseRevitContext` and `ManifestSettings.ContextName`)
+        /// </summary>
+        [Parameter]
+        int RevitContextVersion => TryGetValue<int?>(() => RevitContextVersion) ?? 2027;
     }
 }

--- a/ricaun.Nuke.PackageBuilder/Components/Revit/IHazRevitPackageBuilder.cs
+++ b/ricaun.Nuke.PackageBuilder/Components/Revit/IHazRevitPackageBuilder.cs
@@ -54,14 +54,20 @@ namespace ricaun.Nuke.Components
         string VendorDescription => TryGetValue(() => VendorDescription) ?? VendorId;
 
         /// <summary>
-        /// RevitContext (Support in Revit 2027+)
+        /// RevitContextIsolation (Support in Revit 2027+) (Default: false)
         /// </summary>
+        /// <remarks>
+        /// When enabled the `ManifestSettings.UseRevitContext` is set to false and the addin is loaded in a isolated context.
+        /// </remarks>
         [Parameter]
-        bool RevitContext => TryGetValue<bool?>(() => RevitContext) ?? false;
+        bool RevitContextIsolation => TryGetValue<bool?>(() => RevitContextIsolation) ?? false;
 
         /// <summary>
         /// RevitContextName (Support in Revit 2027+)
         /// </summary>
+        /// <remarks>
+        /// When used the `ManifestSettings.UseRevitContext` is set to false and the addin is loaded in a isolated context with a custom `ManifestSettings.ContextName`.
+        /// </remarks>
         [Parameter]
         string RevitContextName => TryGetValue(() => RevitContextName) ?? null;
 

--- a/ricaun.Nuke.PackageBuilder/Components/Revit/IRevitPackageBuilder.cs
+++ b/ricaun.Nuke.PackageBuilder/Components/Revit/IRevitPackageBuilder.cs
@@ -171,14 +171,14 @@ namespace ricaun.Nuke.Components
                 var folder = file.Parent;
                 SignFolder(folder, $"*{project.Name}*");
                 var builder = new RevitProjectAddInsBuilder(project, file, Application, ApplicationType, VendorId, VendorDescription);
-                if (RevitContext || RevitContextName != null)
+                if (RevitContextIsolation || RevitContextName != null)
                 {
                     var fileRevitVersion = RevitExtension.GetRevitVersion(file);
                     const int ManifestSettingsSupportVersion = 2026;
                     if (fileRevitVersion >= RevitContextVersion && fileRevitVersion >= ManifestSettingsSupportVersion)
                     {
                         var manifestSettings = builder.CreateManifestSettings();
-                        manifestSettings.UseRevitContext = true;
+                        manifestSettings.UseRevitContext = false;
                         manifestSettings.ContextName = RevitContextName;
                         Serilog.Log.Information($"Create AddIns ManifestSettings.UseRevitContext in Revit {fileRevitVersion} with ContextName '{RevitContextName}'");
                     }

--- a/ricaun.Nuke.PackageBuilder/Components/Revit/IRevitPackageBuilder.cs
+++ b/ricaun.Nuke.PackageBuilder/Components/Revit/IRevitPackageBuilder.cs
@@ -170,8 +170,20 @@ namespace ricaun.Nuke.Components
             {
                 var folder = file.Parent;
                 SignFolder(folder, $"*{project.Name}*");
-                new RevitProjectAddInsBuilder(project, file, Application, ApplicationType, VendorId, VendorDescription)
-                    .Build(file);
+                var builder = new RevitProjectAddInsBuilder(project, file, Application, ApplicationType, VendorId, VendorDescription);
+                if (RevitContext || RevitContextName != null)
+                {
+                    var fileRevitVersion = RevitExtension.GetRevitVersion(file);
+                    const int ManifestSettingsSupportVersion = 2026;
+                    if (fileRevitVersion >= RevitContextVersion && fileRevitVersion >= ManifestSettingsSupportVersion)
+                    {
+                        var manifestSettings = builder.CreateManifestSettings();
+                        manifestSettings.UseRevitContext = true;
+                        manifestSettings.ContextName = RevitContextName;
+                        Serilog.Log.Information($"Create AddIns ManifestSettings.UseRevitContext in Revit {fileRevitVersion} with ContextName '{RevitContextName}'");
+                    }
+                }
+                builder.Build(file);
             });
         }
 

--- a/ricaun.Nuke.PackageBuilder/Components/Revit/IRevitPackageBuilder.cs
+++ b/ricaun.Nuke.PackageBuilder/Components/Revit/IRevitPackageBuilder.cs
@@ -170,20 +170,9 @@ namespace ricaun.Nuke.Components
             {
                 var folder = file.Parent;
                 SignFolder(folder, $"*{project.Name}*");
-                var builder = new RevitProjectAddInsBuilder(project, file, Application, ApplicationType, VendorId, VendorDescription);
-                if (RevitContextIsolation || RevitContextName != null)
-                {
-                    var fileRevitVersion = RevitExtension.GetRevitVersion(file);
-                    const int ManifestSettingsSupportVersion = 2026;
-                    if (fileRevitVersion >= RevitContextVersion && fileRevitVersion >= ManifestSettingsSupportVersion)
-                    {
-                        var manifestSettings = builder.CreateManifestSettings();
-                        manifestSettings.UseRevitContext = false;
-                        manifestSettings.ContextName = RevitContextName;
-                        Serilog.Log.Information($"Create AddIns ManifestSettings.UseRevitContext in Revit {fileRevitVersion} with ContextName '{RevitContextName}'");
-                    }
-                }
-                builder.Build(file);
+                new RevitProjectAddInsBuilder(project, file, Application, ApplicationType, VendorId, VendorDescription)
+                    .AddInContextIsolation(file, RevitContextIsolation, RevitContextName, RevitContextVersion)
+                    .Build(file);
             });
         }
 

--- a/ricaun.Nuke.PackageBuilder/Extensions/RevitAddInsBuilderManifestSettingsExtensions.cs
+++ b/ricaun.Nuke.PackageBuilder/Extensions/RevitAddInsBuilderManifestSettingsExtensions.cs
@@ -1,0 +1,45 @@
+﻿using System.Xml.Serialization;
+using Autodesk.PackageBuilder;
+
+namespace ricaun.Nuke.Extensions
+{
+    /// <summary>
+    /// Provides extension methods for the <see cref="RevitAddInsBuilder"/> class.
+    /// </summary>
+    public static class RevitAddInsBuilderManifestSettingsExtensions
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="ManifestSettings"/> and adds it to the builder.
+        /// </summary>
+        /// <param name="builder">The <see cref="RevitAddInsBuilder"/> instance to extend.</param>
+        /// <returns>A new instance of <see cref="ManifestSettings"/>.</returns>
+        public static ManifestSettings CreateManifestSettings(this RevitAddInsBuilder builder)
+        {
+            var manifestSettings = new ManifestSettings();
+            builder.DataBuilder.CreateElement(nameof(ManifestSettings), manifestSettings);
+            return manifestSettings;
+        }
+
+        /// <summary>
+        /// Represents the manifest settings for Revit 2026.
+        /// </summary>
+        /// <remarks>
+        /// For more information, see:
+        /// https://help.autodesk.com/view/RVT/2026/ENU/?guid=Revit_API_Revit_API_Developers_Guide_Introduction_Add_In_Integration_Add_in_Dependency_Isolation_html
+        /// </remarks>
+        public class ManifestSettings
+        {
+            /// <summary>
+            /// Gets or sets a value indicating whether to use the Revit context.
+            /// </summary>
+            [XmlElement]
+            public bool UseRevitContext { get; set; }
+
+            /// <summary>
+            /// Gets or sets the name of the context.
+            /// </summary>
+            [XmlElement]
+            public string ContextName { get; set; }
+        }
+    }
+}

--- a/ricaun.Nuke.PackageBuilder/PackageBuilder/Revit/RevitProjectAddInsBuilderExtension.cs
+++ b/ricaun.Nuke.PackageBuilder/PackageBuilder/Revit/RevitProjectAddInsBuilderExtension.cs
@@ -1,0 +1,45 @@
+﻿using ricaun.Nuke.Extensions;
+
+namespace ricaun.Nuke.Components;
+
+/// <summary>
+/// Provides extension methods for <see cref="RevitProjectAddInsBuilder"/> to configure Revit add-ins.
+/// </summary>
+public static class RevitProjectAddInsBuilderExtension
+{
+    /// <summary>
+    /// For more information, see:
+    /// https://help.autodesk.com/view/RVT/2026/ENU/?guid=Revit_API_Revit_API_Developers_Guide_Introduction_Add_In_Integration_Add_in_Dependency_Isolation_html
+    /// </summary>
+    private const int ManifestSettingsSupportVersion = 2026;
+
+    /// <summary>
+    /// Configures the Revit add-in context isolation settings for the specified builder.
+    /// </summary>
+    /// <param name="builder">The <see cref="RevitProjectAddInsBuilder"/> instance to configure.</param>
+    /// <param name="file">The file path of the Revit add-in.</param>
+    /// <param name="revitContextIsolation">Indicates whether context isolation is enabled.</param>
+    /// <param name="revitContextName">The name of the Revit context.</param>
+    /// <param name="revitContextVersion">The minimum Revit version required for context isolation.</param>
+    /// <returns>The configured <see cref="RevitProjectAddInsBuilder"/> instance.</returns>
+    public static RevitProjectAddInsBuilder AddInContextIsolation(this RevitProjectAddInsBuilder builder,
+        string file,
+        bool revitContextIsolation,
+        string revitContextName,
+        int revitContextVersion)
+    {
+        if (revitContextIsolation || revitContextName != null)
+        {
+            var fileRevitVersion = RevitExtension.GetRevitVersion(file);
+            if (fileRevitVersion >= revitContextVersion && fileRevitVersion >= ManifestSettingsSupportVersion)
+            {
+                var manifestSettings = builder.CreateManifestSettings();
+                manifestSettings.UseRevitContext = false;
+                manifestSettings.ContextName = revitContextName;
+                Serilog.Log.Information($"Create AddIns ManifestSettings.UseRevitContext in Revit {fileRevitVersion} with ContextName '{revitContextName}'");
+            }
+        }
+
+        return builder;
+    }
+}


### PR DESCRIPTION
### Features
- Support `RevitContextIsolation` to enable `UseRevitContext` in the addin build.
### Updated
- Add `IHazRevitPackageBuilder.RevitContextIsolation` to enable `ManifestSettings.UseRevitContext` to `false` in the addin build.
- Add `IHazRevitPackageBuilder.RevitContextName` to set the `ManifestSettings.ContextName` in the addin build.
- Add `IHazRevitPackageBuilder.RevitContextVersion` to set the lowest version that support the `ManifestSettings` in the addin build.
- Add `RevitProjectAddInsBuilderExtension` to enable `AddInContextIsolation`.