### PR TITLE
Version 1.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.11.4] / 2026-04-16
+### Updates
+- Update `ricaun.Nuke` to `1.11.3` to update packages and fix vulnerabilities.
+
 ## [1.11.3] / 2026-04-08
 ### Features
 - Support `RevitContextIsolation` to enable `UseRevitContext` in the addin build.
@@ -399,6 +403,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - First Release
 
 [vNext]: ../../compare/1.0.0...HEAD
+[1.11.4]: ../../compare/1.11.3...1.11.4
 [1.11.3]: ../../compare/1.11.2...1.11.3
 [1.11.2]: ../../compare/1.11.1...1.11.2
 [1.11.1]: ../../compare/1.11.0...1.11.1

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.11.3</Version>
+    <Version>1.11.4-alpha</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.11.4-rc</Version>
+    <Version>1.11.4</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.11.4-beta</Version>
+    <Version>1.11.4-rc</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.11.4-alpha</Version>
+    <Version>1.11.4-beta</Version>
   </PropertyGroup>
 </Project>

--- a/ricaun.Nuke.PackageBuilder/ricaun.Nuke.PackageBuilder.csproj
+++ b/ricaun.Nuke.PackageBuilder/ricaun.Nuke.PackageBuilder.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="!$(Configuration.Contains('Debug'))">
-    <GenerateDocumentationFile>true</GenerateDocumentationFile >
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <DebugType>portable</DebugType>
@@ -57,10 +57,6 @@
     <PackageReference Include="Autodesk.PackageBuilder" Version="*" />
     <PackageReference Include="ricaun.Nuke" Version="*-*" />
   </ItemGroup>
-
-  <PropertyGroup Condition="!$(Configuration.Contains('Debug'))">
-    <NoWarn>NU1903</NoWarn>
-  </PropertyGroup>
 
   <!--
   <ItemGroup>


### PR DESCRIPTION
### Updates
- Update `ricaun.Nuke` to `1.11.3` to update packages and fix vulnerabilities.