### PR TITLE
Version 1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.13.0] / 2026-05-14
+## [1.13.0] / 2026-05-14 - 2026-07-24
 ### Features
 - Support existent `.addin` file inside the `.bundle`. (Fix: #79)
 ### Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.12.1] / 2026-05-14
+### Features
+### Updates
+- Update `CreateRevitAddinOnProjectFiles` to ignore when `.addin` already exists. (Fix: #78) 
+- Update `CreateRevitAddinOnProjectFiles` to create a single `.addin` file per project. (Fix: #78) 
+
 ## [1.12.0] / 2026-04-30
 ### Features
 - Update `ricaun.Nuke` to `1.12.0` to prefer build using `msbuild` and fallback to use `dotnet build`. (Fix: [ricaun.Nuke#90](https://github.com/ricaun-io/ricaun.Nuke/issues/90))
@@ -407,6 +413,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - First Release
 
 [vNext]: ../../compare/1.0.0...HEAD
+[1.12.1]: ../../compare/1.12.0...1.12.1
 [1.12.0]: ../../compare/1.11.4...1.12.0
 [1.11.4]: ../../compare/1.11.3...1.11.4
 [1.11.3]: ../../compare/1.11.2...1.11.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.12.1] / 2026-05-14
 ### Features
+- Support existent `.addin` file inside the `.bundle`. (Fix: #79)
 ### Updates
 - Update `CreateRevitAddinOnProjectFiles` to ignore when `.addin` already exists. (Fix: #78) 
 - Update `CreateRevitAddinOnProjectFiles` to create a single `.addin` file per project. (Fix: #78) 
+- Update `RevitContentsBuilder` to support existent `.addin` file by grouping. (Fix: #79)
 
 ## [1.12.0] / 2026-04-30
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update `CreateRevitAddinOnProjectFiles` to ignore when `.addin` already exists. (Fix: #78) 
 - Update `CreateRevitAddinOnProjectFiles` to create a single `.addin` file per project. (Fix: #78) 
 - Update `RevitContentsBuilder` to support existent `.addin` file by grouping. (Fix: #79)
+- Update `ricaun.Nuke` to `1.12.1` to fix dependency issue.
 
 ## [1.12.0] / 2026-04-30
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.12.1] / 2026-05-14
+## [1.13.0] / 2026-05-14
 ### Features
 - Support existent `.addin` file inside the `.bundle`. (Fix: #79)
 ### Updates
@@ -415,7 +415,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - First Release
 
 [vNext]: ../../compare/1.0.0...HEAD
-[1.12.1]: ../../compare/1.12.0...1.12.1
+[1.13.0]: ../../compare/1.12.0...1.13.0
 [1.12.0]: ../../compare/1.11.4...1.12.0
 [1.11.4]: ../../compare/1.11.3...1.11.4
 [1.11.3]: ../../compare/1.11.2...1.11.3

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.12.1-alpha</Version>
+    <Version>1.13.0-alpha</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.12.0</Version>
+    <Version>1.12.1-alpha</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.13.0-alpha</Version>
+    <Version>1.13.0-beta</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.13.0-beta</Version>
+    <Version>1.13.0-rc</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.13.0-rc</Version>
+    <Version>1.13.0</Version>
   </PropertyGroup>
 </Project>

--- a/RevitAddin.PackageBuilder.Example/RevitAddin.None.addin
+++ b/RevitAddin.PackageBuilder.Example/RevitAddin.None.addin
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RevitAddIns>
+
+</RevitAddIns>

--- a/RevitAddin.PackageBuilder.Example/RevitAddin.PackageBuilder.Example.csproj
+++ b/RevitAddin.PackageBuilder.Example/RevitAddin.PackageBuilder.Example.csproj
@@ -175,4 +175,10 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="RevitAddin.None.addin">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/ricaun.Nuke.PackageBuilder/Components/Revit/IRevitPackageBuilder.cs
+++ b/ricaun.Nuke.PackageBuilder/Components/Revit/IRevitPackageBuilder.cs
@@ -170,9 +170,16 @@ namespace ricaun.Nuke.Components
             {
                 var folder = file.Parent;
                 SignFolder(folder, $"*{project.Name}*");
+                var addinFile = file.WithExtension(".addin");
+                if (addinFile.FileExists())
+                {
+                    Serilog.Log.Information($"File {addinFile} already exists, skipping add-in creation.");
+                    return;
+                }
                 new RevitProjectAddInsBuilder(project, file, Application, ApplicationType, VendorId, VendorDescription)
                     .AddInContextIsolation(file, RevitContextIsolation, RevitContextName, RevitContextVersion)
                     .Build(file);
+                return;
             });
         }
 

--- a/ricaun.Nuke.PackageBuilder/PackageBuilder/Revit/RevitContentsBuilder.cs
+++ b/ricaun.Nuke.PackageBuilder/PackageBuilder/Revit/RevitContentsBuilder.cs
@@ -48,42 +48,55 @@ namespace ricaun.Nuke.Components
             CompanyDetails
                 .Create(project.GetCompany());
 
-            var addinFiles = Globbing.GlobFiles(bundleDirectory, $"**/*{project.Name}*.addin");
+            var allAddinFiles = Globbing.GlobFiles(bundleDirectory, $"**/*.addin");
 
-            var fileVersion = new Dictionary<int, AbsolutePath>();
+            string ReplaceNumbers(string input) => new string(input.Select(c => char.IsDigit(c) ? '#' : c).ToArray());
 
-            var lastVersion = 0;
-            foreach (var addinFile in addinFiles)
+            var groupAddinFiles = allAddinFiles
+                .GroupBy(e => ReplaceNumbers(e.Name))
+                .ToDictionary(g => g.Key, g => g.ToList());
+
+            foreach (var groupAddinFile in groupAddinFiles)
             {
-                lastVersion = AddRevitComponentsByFileVersion(project, addinFile, bundleDirectory);
-                fileVersion[lastVersion] = addinFile;
-            }
+                var groupName = groupAddinFile.Key;
+                var addinFiles = groupAddinFile.Value;
 
-            if (middleVersionRevit)
-            {
-                Serilog.Log.Information($"Components Middle Version");
-                var versions = fileVersion.Keys.ToList();
-                var lowVersion = versions.Min();
-                for (int v = versions.Min(); v < versions.Max(); v++)
+                Serilog.Log.Information($"Group Addin Revit Files '{groupName}'");
+
+                var fileVersion = new Dictionary<int, AbsolutePath>();
+
+                var lastVersion = 0;
+                foreach (var addinFile in addinFiles)
                 {
-                    if (versions.Contains(v))
+                    lastVersion = AddRevitComponentsByFileVersion(project, addinFile, bundleDirectory);
+                    fileVersion[lastVersion] = addinFile;
+                }
+
+                if (middleVersionRevit)
+                {
+                    Serilog.Log.Information($"Components Middle Version");
+                    var versions = fileVersion.Keys.ToList();
+                    var lowVersion = versions.Min();
+                    for (int v = versions.Min(); v < versions.Max(); v++)
                     {
-                        lowVersion = v;
-                        continue;
+                        if (versions.Contains(v))
+                        {
+                            lowVersion = v;
+                            continue;
+                        }
+                        AddRevitComponentsByFileVersion(project, fileVersion[lowVersion], bundleDirectory, v);
                     }
-                    AddRevitComponentsByFileVersion(project, fileVersion[lowVersion], bundleDirectory, v);
                 }
-            }
 
-            if (lastVersionRevit && LastVersionPlusYear > 0)
-            {
-                Serilog.Log.Information($"Components Last Version");
-                while (lastVersion <= DateTime.Now.Year + LastVersionPlusYear)
+                if (lastVersionRevit && LastVersionPlusYear > 0)
                 {
-                    lastVersion = AddRevitComponentsByFileVersion(project, addinFiles.Last(), bundleDirectory, lastVersion + 1);
+                    Serilog.Log.Information($"Components Last Version");
+                    while (lastVersion <= DateTime.Now.Year + LastVersionPlusYear)
+                    {
+                        lastVersion = AddRevitComponentsByFileVersion(project, addinFiles.Last(), bundleDirectory, lastVersion + 1);
+                    }
                 }
             }
-
         }
 
         private int AddRevitComponentsByFileVersion(Project project, AbsolutePath addinFile, AbsolutePath bundleDirectory, int version = 0)
@@ -112,7 +125,7 @@ namespace ricaun.Nuke.Components
                 .ModuleName(moduleName)
                 .RevitPlatform(version);
 
-            Serilog.Log.Information($"Component Revit {version}: {Path.GetFileName(dll)}");
+            Serilog.Log.Information($"Component Revit {version}: {Path.GetFileName(addinFile)}");
 
             return version;
         }


### PR DESCRIPTION
### Features
- Support existent `.addin` file inside the `.bundle`. (Fix: #79)
### Updates
- Update `CreateRevitAddinOnProjectFiles` to ignore when `.addin` already exists. (Fix: #78) 
- Update `CreateRevitAddinOnProjectFiles` to create a single `.addin` file per project. (Fix: #78) 
- Update `RevitContentsBuilder` to support existent `.addin` file by grouping. (Fix: #79)
- Update `ricaun.Nuke` to `1.12.1` to fix dependency issue.